### PR TITLE
[FIX] during the presence of missing data, the script will ignore the…

### DIFF
--- a/analysis/bs1116.py
+++ b/analysis/bs1116.py
@@ -44,9 +44,8 @@ def plot_bs1116_results(listeners_dict,
     all_listeners_filename = output_dir + "%s_all_listeners.png" % test_name
     plot_all_listeners(listeners_dict, all_listeners_filename, title=test_name)
 
-    if len(listeners_dict) > 1:
-        all_items_filename = output_dir + "%s_all_items.png" % test_name
-        plot_all(listeners_dict, all_items_filename, title=test_name)
+    all_items_filename = output_dir + "%s_all_items.png" % test_name
+    plot_all(listeners_dict, all_items_filename, title=test_name)
 
     if show_plots:
         matplotlib.pyplot.show()

--- a/analysis/mushra.py
+++ b/analysis/mushra.py
@@ -44,9 +44,8 @@ def plot_mushra_results(listeners_dict,
     all_listeners_filename = output_dir + "%s_all_listeners.png" % test_name
     plot_all_listeners(listeners_dict, all_listeners_filename, title=test_name)
 
-    if len(listeners_dict) > 1:
-        all_items_filename = output_dir + "%s_all_items.png" % test_name
-        plot_all(listeners_dict, all_items_filename, title=test_name)
+    all_items_filename = output_dir + "%s_all_items.png" % test_name
+    plot_all(listeners_dict, all_items_filename, title=test_name)
 
     if show_plots:
         matplotlib.pyplot.show()


### PR DESCRIPTION
This PR should fix the situation when the data is incomplete. 

The original script assumes that all stimuli get all the treatments (fully complete). However, in some cases where only a few stimuli get a subset of treatments, NaN will appear in the dataframe, and the estimation of confidence intervals will become problematic. 

In this PR, this situation would be handled by ignoring NaN or, in the most extreme case, returning zeros for the estimated confidence intervals. This allows the script to still produce plots in the presence of missing data. 